### PR TITLE
Leverage device data to enable Braintree's advanced fraud protection tools

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -344,6 +344,8 @@ module SolidusPaypalBraintree
         params[:payment_method_nonce] = source.nonce
       end
 
+      params[:device_data] = source.device_data
+
       if source.paypal?
         params[:shipping] = braintree_shipping_address(options)
       end

--- a/db/migrate/20220922140116_add_device_data_to_braintree_sources.rb
+++ b/db/migrate/20220922140116_add_device_data_to_braintree_sources.rb
@@ -1,0 +1,5 @@
+class AddDeviceDataToBraintreeSources < ActiveRecord::Migration[5.1]
+  def change
+    add_column :solidus_paypal_braintree_sources, :device_data, :string
+  end
+end

--- a/lib/solidus_paypal_braintree/engine.rb
+++ b/lib/solidus_paypal_braintree/engine.rb
@@ -20,7 +20,7 @@ module SolidusPaypalBraintree
 
     initializer "register_solidus_paypal_braintree_gateway", after: "spree.register.payment_methods" do |app|
       app.config.spree.payment_methods << SolidusPaypalBraintree::Gateway
-      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type]
+      Spree::PermittedAttributes.source_attributes.concat [:nonce, :payment_type, :device_data]
     end
 
     if SolidusSupport.frontend_available?

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
       nonce: 'fake-valid-nonce',
       user: user,
       payment_type: payment_type,
-      payment_method: gateway
+      payment_method: gateway,
+      device_data: 'fake-device-data'
     )
   end
 


### PR DESCRIPTION
This PR includes a migrations that adds `device_data` to `SolidusPaypalBraintree::Source`. Adding this field allows for the use of Braintree's advanced fraud protection tools.